### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && \
     rm -rf /var/cache/apt/* && \
     adduser --disabled-password --gecos "" runner
 
-ARG runner_version="2.277.1"
+ARG runner_version="2.278.0"
 ARG runner_architecture="x64"
 
 RUN curl -OL https://github.com/actions/runner/releases/download/v${runner_version}/actions-runner-linux-${runner_architecture}-${runner_version}.tar.gz && \


### PR DESCRIPTION
This commit is to support github runnner version 2.278.0.
It version is pre-release.