### PR TITLE
Bump runner to 2.287.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && \
     rm -rf /var/cache/apt/* && \
     adduser --disabled-password --gecos "" runner
 
-ARG runner_version="2.286.1"
+ARG runner_version="2.287.1"
 ARG runner_architecture="x64"
 
 RUN curl -OL https://github.com/actions/runner/releases/download/v${runner_version}/actions-runner-linux-${runner_architecture}-${runner_version}.tar.gz && \


### PR DESCRIPTION
This commit is just to bump GitHub Actions self-hosted runner to 2.287.1.
